### PR TITLE
Feat - Install JQ as OS package

### DIFF
--- a/bin/ham-install-os-packages
+++ b/bin/ham-install-os-packages
@@ -15,16 +15,22 @@ case $HAM_OS in
         brew install awsebcli awscli
         # Install *watchman* for react-native development
         brew install watchman
+        # Install *jq*
+        brew install jq
         ;;
     LINUX)
         if [ $(type apt-get 2>/dev/null | wc -l) = 1 ]; then
             echo "### Installing packages required by ham on Linux (apt-get) ###"
             echo "I/Installing apt-get packages"
-            sudo apt-get -y install xsltproc p7zip-full git curl gcc g++ clang ffmpeg libcurl4-openssl-dev mesa-common-dev mesa-utils freeglut3-dev libsdl2-dev python3-pip
+            sudo apt-get -y install \
+              xsltproc p7zip-full git curl gcc g++ clang ffmpeg \
+              libcurl4-openssl-dev mesa-common-dev mesa-utils \
+              freeglut3-dev libsdl2-dev python3-pip
         elif [ $(type pacman 2>/dev/null | wc -l) = 1 ]; then
             echo "### Installing packages required by ham on Linux (pacman) ###"
             echo "I/Installing pacman packages"
-            sudo pacman -S install libxslt p7zip git python-pip
+            sudo pacman -S install \
+              libxslt p7zip git python-pip jq
         else
             echo "E/Unsupported LINUX package manager"
             return 1


### PR DESCRIPTION
Install "jq" (see https://stedolan.github.io/jq) as OS package such that we can use it for JSON filtering.

Run os install script:
```$ ham-install-os-packages```

Once done, running the following should show path for `jq`:
```$ type jq```
